### PR TITLE
Fix fetch handling and add iframe original view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,9 @@
     <label><input type="checkbox" id="original"> Original View</label>
     <label><input type="checkbox" id="dark"> Dark Mode</label>
   </div>
-  <div id="content"></div>
+  <div id="spinner" style="display:none">Loading...</div>
+  <div id="readerContent"></div>
+  <iframe id="originalFrame" style="display:none" ></iframe>
   <script src="main.js"></script>
 </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,25 +1,42 @@
 const loadBtn = document.getElementById('load');
 const urlInput = document.getElementById('url');
-const contentDiv = document.getElementById('content');
+const readerDiv = document.getElementById('readerContent');
+const iframe = document.getElementById('originalFrame');
 const originalToggle = document.getElementById('original');
 const darkToggle = document.getElementById('dark');
+const spinner = document.getElementById('spinner');
 
 loadBtn.addEventListener('click', async () => {
   const url = urlInput.value.trim();
   if (!url) return;
-  const resp = await fetch(`/fetch?url=${encodeURIComponent(url)}`);
-  const data = await resp.json();
-  document.title = data.title;
-  contentDiv.innerHTML = data.content;
+  readerDiv.innerHTML = '';
+  iframe.src = '';
+  spinner.style.display = 'block';
+  originalToggle.checked = false;
+  readerDiv.style.display = 'block';
+  iframe.style.display = 'none';
+  try {
+    const resp = await fetch(`/fetch?url=${encodeURIComponent(url)}`);
+    const data = await resp.json();
+    spinner.style.display = 'none';
+    if (data.error) {
+      readerDiv.textContent = data.error;
+      document.title = 'Thermos Reader';
+    } else {
+      document.title = data.title;
+      readerDiv.innerHTML = data.content || '';
+      iframe.src = url;
+    }
+  } catch (err) {
+    spinner.style.display = 'none';
+    readerDiv.textContent = 'Failed to load';
+  }
 });
 
 originalToggle.addEventListener('change', () => {
-  const url = urlInput.value.trim();
-  if (!url) return;
-  if (originalToggle.checked) {
-    window.open(url, '_blank');
-    originalToggle.checked = false;
-  }
+  const showOriginal = originalToggle.checked;
+  readerDiv.style.display = showOriginal ? 'none' : 'block';
+  iframe.style.display = showOriginal ? 'block' : 'none';
 });
 
 darkToggle.addEventListener('change', () => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -15,8 +15,13 @@ body {
   margin-bottom: 1rem;
 }
 
-#content p,
-#content h1, #content h2, #content h3,
-#content ul, #content ol {
+#readerContent p,
+#readerContent h1, #readerContent h2, #readerContent h3,
+#readerContent ul, #readerContent ol {
   margin: 1rem 0;
+}
+
+#originalFrame {
+  width: 100%;
+  border: none;
 }


### PR DESCRIPTION
## Summary
- ensure URLs are decoded/validated and errors are handled
- show sanitized fallback when Readability fails
- toggle between reader content and embedded original via iframe
- add loading spinner and style updates
- use Node's global `fetch`

## Testing
- `npm install`
- `node server.js` *(fails: fetch failed for example URL)*


------
https://chatgpt.com/codex/tasks/task_e_683f7eaab0b88320907c03491b0cf396