### PR TITLE
Add standalone CLI script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,19 @@ Then open [http://localhost:3000](http://localhost:3000) and enter a URL to view
 ## Security
 
 All remote pages are fetched and sanitized server-side using DOMPurify.
+
+## Standalone CLI
+
+You can also fetch and render an article directly from the command line without
+running the server:
+
+```bash
+npm run cli -- <url>
+```
+
+The command prints sanitized HTML to stdout. Redirect it to a file to view in a
+browser:
+
+```bash
+npm run cli -- https://example.com > article.html
+```

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,52 @@
+const { JSDOM } = require('jsdom');
+const { Readability } = require('@mozilla/readability');
+const createDOMPurify = require('dompurify');
+
+async function main() {
+  const url = process.argv[2];
+  if (!url || !/^https?:\/\//i.test(url)) {
+    console.error('Usage: node cli.js <url>');
+    process.exit(1);
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36'
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error('fetch failed');
+    }
+
+    const html = await response.text();
+    const dom = new JSDOM(html, { url });
+    const purify = createDOMPurify(dom.window);
+    const reader = new Readability(dom.window.document);
+
+    let article;
+    let content = '';
+    let title = dom.window.document.title;
+
+    try {
+      article = reader.parse();
+    } catch (e) {}
+
+    if (article && article.content) {
+      content = purify.sanitize(article.content);
+      title = article.title || title;
+    } else {
+      const fallback = purify.sanitize(dom.window.document.body.innerHTML);
+      content = fallback || '<p>No readable content.</p>';
+    }
+
+    const output = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${title}</title></head><body>${content}</body></html>`;
+    console.log(output);
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "cli": "node cli.js"
   },
   "keywords": [],
   "author": "",

--- a/startHere.md
+++ b/startHere.md
@@ -49,6 +49,7 @@ thermos
 │   ├── index.html       # UI shell & JS
 │   ├── main.js          # Fetch + toggle logic
 │   └── styles.css       # Light & dark theme
+├── cli.js              # Standalone command line fetcher
 └── README.md
 ```
 
@@ -124,6 +125,16 @@ thermos
 * [ ] Loading *dallaslibrary2.org* returns readable content.
 * [ ] Dark mode toggle flips colors instantly.
 * [ ] Original view opens (iframe or new tab) and handles sites that deny framing.
+
+### CLI Usage
+
+To grab an article without running the server, use the standalone script:
+
+```bash
+npm run cli -- <url>
+```
+
+It prints sanitized HTML to stdout. Redirect it to a file to read in your browser.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `cli.js` for command line usage
- document CLI usage in README and setup notes
- update project structure listing in startHere.md
- expose npm script `cli` for standalone runs

## Testing
- `npm install`
- `npm run cli -- https://example.com` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_683f8488ecac8320aad33a15e839252e